### PR TITLE
wrong check in web socket. [ None != 0 ]

### DIFF
--- a/quotexpy/__init__.py
+++ b/quotexpy/__init__.py
@@ -54,9 +54,9 @@ class Quotex(object):
 
     @staticmethod
     def check_connect():
-        if global_value.check_websocket_if_connect == 0:
-            return False
-        return True
+        if global_value.check_websocket_if_connect == 1:
+            return True
+        return False
 
     async def re_subscribe_stream(self):
         try:


### PR DESCRIPTION
ineffective/wrong check (global_value.check_websocket_if_connect) as default value seems to be None. and "None" is not equal to "0". check websocket via "1" to return True else False. better and correct approach.

the previous check results in multiple websockets connections as the global_value.check_websocket_if_connect seems to be wrongly used. thanks