### PR TITLE
Added user credentials validation logic and externalise Time Period

### DIFF
--- a/quotexpy/__init__.py
+++ b/quotexpy/__init__.py
@@ -14,7 +14,8 @@ from quotexpy.utils.account_type import AccountType
 
 
 class Quotex(object):
-    def __init__(self, email="", password="", **kwargs):
+
+    def __init__(self, email="", password="", time_period: int = 60, **kwargs):
         self.api = None
         self.email = email
         self.password = password
@@ -31,6 +32,12 @@ class Quotex(object):
         self.websocket_client = None
         self.websocket_thread = None
 
+        # Validate User Credentials
+        if not self.email.strip():
+            self.email = input("Enter your email id: ")
+        if not self.password.strip():
+            self.password = input("Enter your password: ")
+
         self.logger = logging.getLogger(__name__)
 
     @property
@@ -42,7 +49,7 @@ class Quotex(object):
         return self.websocket_client.wss
 
     async def connect(self) -> bool:
-        self.api = QuotexAPI(self.email, self.password, **self.kwargs)
+        self.api = QuotexAPI(self.email, self.password, self.time_period, **self.kwargs)
         self.api.trace_ws = self.trace_ws
         ok = await self.api.connect()
         if ok:

--- a/quotexpy/api.py
+++ b/quotexpy/api.py
@@ -71,7 +71,7 @@ class QuotexAPI(object):
     balance_id = None
     settings = None
 
-    def __init__(self, email="", password="", **kwargs):
+    def __init__(self, email="", password="", time_period: int = 60, **kwargs):
         """
         :param email: The email of a Quotex account.
         :param password: The password of a Quotex account.
@@ -80,6 +80,7 @@ class QuotexAPI(object):
         self.password = password
 
         self.kwargs = kwargs
+        self.time_period = time_period
         self._temp_status = ""
 
         self.cookies = None


### PR DESCRIPTION
Please consider externalizing time period to enable users to specify them during the creation of a Quotex client.
Currently, the 'send_websocket_request' function does not utilize the period argument provided.

@SantiiRepair  Kindly review and advise if any additional adjustments are necessary.
